### PR TITLE
Added Client-ID to headers in all requests

### DIFF
--- a/src/API/Api.php
+++ b/src/API/Api.php
@@ -32,9 +32,11 @@ class Api
     public function __construct($clientId = null, $token = null)
     {
 
-        // Set clientId if given
+        // Set clientId if given else get from config
         if($clientId) {
             $this->setClientId($clientId);
+        } else if(config('twitch-api.client_id')) {
+            $this->setClientId(config('twitch-api.client_id'));
         }
 
         // Set token if given
@@ -72,11 +74,9 @@ class Api
     public function getClientId($clientId = null)
     {
 
-        // Return given parameter or config value
+        // Return given parameter
         if($clientId) {
             return $clientId;
-        } else if(config('twitch-api.client_id')){
-            return config('twitch-api.client_id');
         }
 
         // If clientId is null and no clientId has previously been set

--- a/src/API/Api.php
+++ b/src/API/Api.php
@@ -5,6 +5,7 @@ namespace Zarlach\TwitchApi\API;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use Zarlach\TwitchApi\Exceptions\RequestRequiresAuthenticationException;
+use Zarlach\TwitchApi\Exceptions\RequestRequiresClientIdException;
 
 class Api
 {
@@ -12,6 +13,11 @@ class Api
      * @var token
      */
     protected $token;
+
+    /**
+     * @var clientId
+     */
+    protected $clientId;
 
     /**
      * @var GuzzleClient
@@ -23,8 +29,13 @@ class Api
      *
      * @param token $token Twitch OAuth Token
      */
-    public function __construct($token = null)
+    public function __construct($clientId = null, $token = null)
     {
+
+        // Set clientId if given
+        if($clientId) {
+            $this->setClientId($clientId);
+        }
 
         // Set token if given
         if ($token) {
@@ -40,6 +51,41 @@ class Api
                 ]
             ]
         ]);
+    }
+
+    /**
+     * Set clientId
+     *
+     * @var String $clientId Twitch Client-ID
+     */
+    public function setClientId($clientId)
+    {
+        $this->clientId = $clientId;
+    }
+
+    /**
+     * Get clientId
+     *
+     * @param string clientId optional
+     * @return string clientId
+     */
+    public function getClientId($clientId = null)
+    {
+
+        // Return given parameter or config value
+        if($clientId) {
+            return $clientId;
+        } else if(config('twitch-api.client_id')){
+            return config('twitch-api.client_id');
+        }
+
+        // If clientId is null and no clientId has previously been set
+        if(!$this->clientId) {
+            throw new RequestRequiresClientIdException();
+        }
+
+        // Return clientId that has previously been set
+        return $this->clientId;
     }
 
     /**
@@ -85,11 +131,15 @@ class Api
      */
     public function sendRequest($type = 'GET', $path = '', $token = false, $options = [], $availableOptions = [])
     {
+
         // GET parameters
         $path = ($type == 'GET') ? $this->generateUrl($path, $options, $availableOptions) : $path;
 
+        // Get the Client-ID
+        $defaultHeaders = ['Client-ID' => $this->getClientId()];
+
         // Request object
-        $request = new Request($type, $path);
+        $request = new Request($type, $path, $defaultHeaders);
 
         // Data for sending
         $data = $this->generateData($token, $options, $availableOptions);

--- a/src/Exceptions/RequestRequiresClientIdException.php
+++ b/src/Exceptions/RequestRequiresClientIdException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Zarlach\TwitchApi\Exceptions;
+
+use Exception;
+
+class RequestRequiresClientIdException extends Exception
+{
+    public function __construct()
+    {
+        $this->message = 'Request requires Client-ID';
+    }
+}


### PR DESCRIPTION
Fixes issue: #1 

I've added the option to pass clientId in constructor. If clientId isn't set it will try go get the twitch-api.client_id value from Laravel's configuration settings.
