### PR TITLE
[BUGFIX] force_verify should use string instead of integer

### DIFF
--- a/src/API/Authentication.php
+++ b/src/API/Authentication.php
@@ -22,7 +22,7 @@ class Authentication extends Api
         .'&redirect_uri='.config('twitch-api.redirect_url')
         .'&scope='.implode(config('twitch-api.scopes'), '+')
         .'&state='.$state
-        .'&force_verify='.$forceVerify;
+        .'&force_verify='.($forceVerify ? 'true' : 'false');
     }
 
     /**


### PR DESCRIPTION
Related #13